### PR TITLE
Pin GitHub Actions by digest in the default Renovate preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,6 +7,7 @@
     ":semanticCommits",
     ":enableVulnerabilityAlerts",
     ":pinDevDependencies",
+    "helpers:pinGitHubActionDigests",
     "group:allNonMajor"
   ],
   "configMigration": true,


### PR DESCRIPTION
## Summary
- Add `helpers:pinGitHubActionDigests` to the shared Renovate preset.
- This forces GitHub Actions references to resolve to immutable commit SHAs.

## Testing
- Not run (not requested)