### PR TITLE
Update Renovate and related tooling dependencies

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.300",
+    "version": "10.0.301",
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "meziantou-renovate-config",
       "devDependencies": {
-        "renovate": "43.214.4"
+        "renovate": "43.227.1"
       }
     },
     "node_modules/@arcanis/slice-ansi": {
@@ -1792,9 +1792,9 @@
       }
     },
     "node_modules/@renovatebot/pgp": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@renovatebot/pgp/-/pgp-1.3.12.tgz",
-      "integrity": "sha512-3glRBjBTgoFHdFedUsxcQWw7C0LfHYhCKzTo9+jqjoI+kk5YD/g7GWJ2hsPSG6WTQqJqD8VGiM0h2j3xqTS4Qw==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@renovatebot/pgp/-/pgp-1.3.14.tgz",
+      "integrity": "sha512-H2BBZmyMHdGNW4LXLHbDXBymeHjwbWZk9vE57Nd6TJCSPTKmf1nz13vzuZHqwF/BCyLSuzMfL8/eOHYgtymUwg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4337,9 +4337,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6484,14 +6484,23 @@
       }
     },
     "node_modules/openpgp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.3.0.tgz",
-      "integrity": "sha512-pLzCU8IgyKXPSO11eeharQkQ4GzOKNWhXq79pQarIRZEMt1/ssyr+MIuWBv1mNoenJLg04gvPx+fi4gcKZ4bag==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.3.1.tgz",
+      "integrity": "sha512-7oSPvmlKPojxFoyelT5DWPIAVmqWZh4qU/5pO6bdoShEtRpCw9Sye9IXUQj6EFM3XpgGssqccAr705YtTcLNQw==",
       "dev": true,
       "license": "LGPL-3.0+",
       "optional": true,
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 18.0.0",
+        "typescript": ">= 5.0.0"
+      },
+      "peerDependencies": {
+        "@openpgp/web-stream-tools": "~0.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@openpgp/web-stream-tools": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-all": {
@@ -6832,11 +6841,10 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.5.0.tgz",
-      "integrity": "sha512-df1jWDPA5VIBNRtuAHjqr09f2qN5D4Vke1wYqOQg1XJ7ZDpA7BD6L7E4tyChgGRLB5hqk2m79Zsy0WHwV9a84A==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.2.tgz",
+      "integrity": "sha512-CCERJxzRvKMeEdJSLwdQf40TXWNPc8M4RkN7j/lxY6FQB+4do8rETWqj60AqxP9n0XIsxnSefZ8uhAaGKg2njw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
@@ -7086,9 +7094,9 @@
       }
     },
     "node_modules/renovate": {
-      "version": "43.214.4",
-      "resolved": "https://registry.npmjs.org/renovate/-/renovate-43.214.4.tgz",
-      "integrity": "sha512-pbLJI8uKGTFmn2B4Iq4tZk3gRdQ2wA8SejLIsEec1LOLqajCAPBiekyr3bLxAwqNX/vlzaSnolUG9fTxQQquTw==",
+      "version": "43.227.1",
+      "resolved": "https://registry.npmjs.org/renovate/-/renovate-43.227.1.tgz",
+      "integrity": "sha512-cF00N1X33lvSQzOccZqryDKeX0xobQRvJJDajpWNC/CfFq62ODJUo1ZywxU7hWJ51A/toAuinw3yKmQvVT5AWw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -7124,7 +7132,7 @@
         "@renovatebot/good-enough-parser": "2.0.1",
         "@renovatebot/osv-offline": "3.0.3",
         "@renovatebot/pep440": "5.0.0",
-        "@renovatebot/pgp": "1.3.12",
+        "@renovatebot/pgp": "1.3.14",
         "@renovatebot/ruby-semver": "5.0.0",
         "@sindresorhus/is": "8.1.0",
         "@yarnpkg/core": "4.8.0",
@@ -7159,7 +7167,7 @@
         "github-url-from-git": "1.5.0",
         "glob": "13.0.6",
         "global-agent": "3.0.0",
-        "google-auth-library": "10.6.2",
+        "google-auth-library": "10.7.0",
         "got": "14.6.6",
         "graph-data-structure": "4.5.0",
         "handlebars": "4.7.9",
@@ -7186,14 +7194,14 @@
         "p-throttle": "8.1.0",
         "parse-link-header": "2.0.0",
         "prettier": "3.8.1",
-        "protobufjs": "8.5.0",
+        "protobufjs": "8.6.2",
         "punycode": "2.3.1",
         "remark": "15.0.1",
         "remark-gfm": "4.0.1",
         "remark-github": "12.0.0",
         "safe-stable-stringify": "2.5.0",
         "sax": "1.6.0",
-        "semver": "7.8.1",
+        "semver": "7.8.3",
         "semver-stable": "3.0.0",
         "semver-utils": "1.1.4",
         "shlex": "3.0.0",
@@ -7216,10 +7224,10 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "pnpm": "^10.0.0"
+        "pnpm": "^11.0.0"
       },
       "optionalDependencies": {
-        "openpgp": "6.3.0",
+        "openpgp": "6.3.1",
         "re2": "1.24.1"
       }
     },
@@ -7430,9 +7438,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "meziantou-renovate-config",
   "private": true,
   "devDependencies": {
-    "renovate": "43.214.4"
+    "renovate": "43.227.1"
   }
 }

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -104,8 +104,8 @@ internal sealed class TestContext : IAsyncDisposable
                 new("RENOVATE_INHERIT_CONFIG", "false"),
                 new("RENOVATE_ONBOARDING", "false"),
                 new("RENOVATE_REQUIRE_CONFIG", "optional"),
-                new("RENOVATE_IGNORE_SCHEDULE", "true"),
                 new("RENOVATE_RECREATE_WHEN", "always"),
+                new("RENOVATE_PR_CREATION", "immediate"),
                 new("RENOVATE_PR_HOURLY_LIMIT", "0"),
                 new("RENOVATE_PR_CONCURRENT_LIMIT", "0"),
                 new("RENOVATE_BRANCH_CONCURRENT_LIMIT", "0"),
@@ -270,6 +270,8 @@ internal sealed class TestContext : IAsyncDisposable
     {
         var root = GetGitRoot();
         var config = JsonNode.Parse(File.ReadAllText(Path.Combine(root, "default.json")))!.AsObject();
+        config["schedule"] = new JsonArray("at any time");
+
         if (automerge)
         {
             var automergeConfig = JsonNode.Parse(File.ReadAllText(Path.Combine(root, "default-automerge.json")))!.AsObject();

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -109,6 +109,7 @@ internal sealed class TestContext : IAsyncDisposable
                 new("RENOVATE_PR_HOURLY_LIMIT", "0"),
                 new("RENOVATE_PR_CONCURRENT_LIMIT", "0"),
                 new("RENOVATE_BRANCH_CONCURRENT_LIMIT", "0"),
+                new("RENOVATE_PRUNE_STALE_BRANCHES", "false"),
                 new("RENOVATE_LABELS", """["renovate-test"]"""),
                 new("GIT_CONFIG_COUNT", "1"),
                 new("GIT_CONFIG_KEY_0", "commit.gpgsign"),

--- a/tests/renovate-config.tests.csproj
+++ b/tests/renovate-config.tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Meziantou.Framework.ProcessWrapper" Version="1.0.16" />
-    <PackageReference Include="Markdig" Version="1.2.0" />
+    <PackageReference Include="Markdig" Version="1.3.0" />
     <PackageReference Include="Meziantou.Framework.InlineSnapshotTesting" Version="3.3.11" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="1.0.13" />
     <PackageReference Include="Octokit" Version="14.0.0" />


### PR DESCRIPTION
## Summary
- Bump `renovate` to `43.227.1` and refresh the lockfile.
- Update the pinned .NET SDK from `10.0.300` to `10.0.301`.
- Add `RENOVATE_PRUNE_STALE_BRANCHES=false` to the test harness to match current Renovate behavior.
- Refresh test dependency versions for `Markdig` and transitive packages.

## Testing
- Not run (not requested)