### PR TITLE
Remove Octokit from tests and use direct HttpClient

### DIFF
--- a/tests/GitHubClient.cs
+++ b/tests/GitHubClient.cs
@@ -1,0 +1,224 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Meziantou.RenovateConfig.Tests;
+
+internal enum PullRequestState
+{
+    Open,
+    Closed,
+    All,
+}
+
+internal sealed class GitHubClient
+{
+    private const string UserAgent = "meziantou-renovate-config-tests";
+    private const int PageSize = 100;
+    private static readonly Uri BaseAddress = new("https://api.github.com/");
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly AuthenticationHeaderValue _authenticationHeader;
+
+    public GitHubClient(string token)
+    {
+        _authenticationHeader = new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    public Task<IReadOnlyList<PullRequest>> GetPullRequestsAsync(string owner, string repository, string baseBranch, PullRequestState state, CancellationToken cancellationToken)
+    {
+        return GetPaginatedAsync<PullRequest>(
+            BuildUri($"repos/{Escape(owner)}/{Escape(repository)}/pulls", [
+                KeyValuePair.Create<string, string?>("base", baseBranch),
+                KeyValuePair.Create<string, string?>("state", state.ToString().ToLowerInvariant()),
+                KeyValuePair.Create<string, string?>("per_page", PageSize.ToString(CultureInfo.InvariantCulture)),
+            ]),
+            cancellationToken);
+    }
+
+    public Task<IReadOnlyList<PullRequestCommit>> GetPullRequestCommitsAsync(string owner, string repository, int pullRequestNumber, CancellationToken cancellationToken)
+    {
+        return GetPaginatedAsync<PullRequestCommit>(
+            BuildUri($"repos/{Escape(owner)}/{Escape(repository)}/pulls/{pullRequestNumber.ToString(CultureInfo.InvariantCulture)}/commits", [
+                KeyValuePair.Create<string, string?>("per_page", PageSize.ToString(CultureInfo.InvariantCulture)),
+            ]),
+            cancellationToken);
+    }
+
+    public async Task<bool> IsPullRequestMergedAsync(string owner, string repository, int pullRequestNumber, CancellationToken cancellationToken)
+    {
+        using var response = await SendAsync(
+            () => CreateRequest(HttpMethod.Get, BuildUri($"repos/{Escape(owner)}/{Escape(repository)}/pulls/{pullRequestNumber.ToString(CultureInfo.InvariantCulture)}/merge")),
+            cancellationToken).ConfigureAwait(false);
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NoContent => true,
+            HttpStatusCode.NotFound => false,
+            _ => await ThrowForUnexpectedStatusAsync(response, cancellationToken).ConfigureAwait(false),
+        };
+    }
+
+    public async Task<string> GetFileContentAsync(string owner, string repository, string path, string gitReference, CancellationToken cancellationToken)
+    {
+        using var response = await SendAsync(
+            () => CreateRequest(HttpMethod.Get, BuildUri($"repos/{Escape(owner)}/{Escape(repository)}/contents/{EscapePath(path)}", [
+                KeyValuePair.Create<string, string?>("ref", gitReference),
+            ])),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+        var file = await DeserializeAsync<RepositoryContent>(response, cancellationToken).ConfigureAwait(false);
+        if (!string.Equals(file.Encoding, "base64", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Unexpected GitHub content encoding '{file.Encoding}'.");
+        }
+
+        var base64 = file.Content.Replace("\n", string.Empty, StringComparison.Ordinal).Replace("\r", string.Empty, StringComparison.Ordinal);
+        return Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+    }
+
+    public Task<IReadOnlyList<Branch>> GetBranchesAsync(string owner, string repository, CancellationToken cancellationToken)
+    {
+        return GetPaginatedAsync<Branch>(
+            BuildUri($"repos/{Escape(owner)}/{Escape(repository)}/branches", [
+                KeyValuePair.Create<string, string?>("per_page", PageSize.ToString(CultureInfo.InvariantCulture)),
+            ]),
+            cancellationToken);
+    }
+
+    public async Task ClosePullRequestAsync(string owner, string repository, int pullRequestNumber, CancellationToken cancellationToken)
+    {
+        using var response = await SendAsync(
+            () => CreateRequest(HttpMethod.Patch, BuildUri($"repos/{Escape(owner)}/{Escape(repository)}/pulls/{pullRequestNumber.ToString(CultureInfo.InvariantCulture)}"), JsonContent.Create(new { state = "closed" })),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteBranchAsync(string owner, string repository, string branchName, CancellationToken cancellationToken)
+    {
+        using var response = await SendAsync(
+            () => CreateRequest(HttpMethod.Delete, BuildUri($"repos/{Escape(owner)}/{Escape(repository)}/git/refs/heads/{EscapePath(branchName)}")),
+            cancellationToken).ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return;
+        }
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<T>> GetPaginatedAsync<T>(Uri uri, CancellationToken cancellationToken)
+    {
+        List<T>? results = null;
+
+        for (var page = 1; ; page++)
+        {
+            using var response = await SendAsync(
+                () => CreateRequest(HttpMethod.Get, AppendQuery(uri, "page", page.ToString(CultureInfo.InvariantCulture))),
+                cancellationToken).ConfigureAwait(false);
+
+            await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var items = await DeserializeAsync<List<T>>(response, cancellationToken).ConfigureAwait(false);
+            results ??= new List<T>(items.Count);
+            results.AddRange(items);
+
+            if (items.Count < PageSize)
+            {
+                return results;
+            }
+        }
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(Func<HttpRequestMessage> requestFactory, CancellationToken cancellationToken)
+    {
+        return await SharedHttpClient.SendAsync(requestFactory, cancellationToken).ConfigureAwait(false);
+    }
+
+    private HttpRequestMessage CreateRequest(HttpMethod method, Uri uri, HttpContent? content = null)
+    {
+        var request = new HttpRequestMessage(method, uri)
+        {
+            Content = content,
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        request.Headers.Authorization = _authenticationHeader;
+        request.Headers.UserAgent.ParseAdd(UserAgent);
+        request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+        return request;
+    }
+
+    private static async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        await ThrowForUnexpectedStatusAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<T> DeserializeAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        return await JsonSerializer.DeserializeAsync<T>(stream, JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"GitHub API response for '{response.RequestMessage?.RequestUri}' was empty.");
+    }
+
+    private static async Task<bool> ThrowForUnexpectedStatusAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        throw new HttpRequestException(
+            $"GitHub API request to '{response.RequestMessage?.RequestUri}' failed with status code {(int)response.StatusCode} ({response.StatusCode}). Body: {body}",
+            inner: null,
+            response.StatusCode);
+    }
+
+    private static Uri BuildUri(string path, params IReadOnlyList<KeyValuePair<string, string?>> queryParameters)
+    {
+        var builder = new UriBuilder(new Uri(BaseAddress, path));
+        if (queryParameters.Count > 0)
+        {
+            builder.Query = string.Join("&", queryParameters.Where(static pair => pair.Value is not null).Select(static pair => $"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(pair.Value!)}"));
+        }
+
+        return builder.Uri;
+    }
+
+    private static Uri AppendQuery(Uri uri, string key, string value)
+    {
+        var builder = new UriBuilder(uri);
+        builder.Query = string.IsNullOrEmpty(builder.Query)
+            ? $"{Uri.EscapeDataString(key)}={Uri.EscapeDataString(value)}"
+            : builder.Query.TrimStart('?') + "&" + $"{Uri.EscapeDataString(key)}={Uri.EscapeDataString(value)}";
+        return builder.Uri;
+    }
+
+    private static string Escape(string value) => Uri.EscapeDataString(value);
+
+    private static string EscapePath(string value) => string.Join("/", value.Split('/').Select(Escape));
+
+    internal sealed record PullRequest(
+        [property: JsonPropertyName("number")] int Number,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("body")] string? Body,
+        [property: JsonPropertyName("labels")] IReadOnlyList<Label> Labels);
+
+    internal sealed record Label([property: JsonPropertyName("name")] string Name);
+
+    internal sealed record PullRequestCommit([property: JsonPropertyName("commit")] CommitDetails Commit);
+
+    internal sealed record CommitDetails([property: JsonPropertyName("message")] string Message);
+
+    internal sealed record Branch([property: JsonPropertyName("name")] string Name);
+
+    internal sealed record RepositoryContent(
+        [property: JsonPropertyName("content")] string Content,
+        [property: JsonPropertyName("encoding")] string Encoding);
+}

--- a/tests/SharedHttpClient.cs
+++ b/tests/SharedHttpClient.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+using System.Net;
+
+namespace Meziantou.RenovateConfig.Tests;
+
+internal static class SharedHttpClient
+{
+    private static readonly HttpClient HttpClient = CreateHttpClient();
+
+    public static async Task<HttpResponseMessage> SendAsync(Func<HttpRequestMessage> requestFactory, CancellationToken cancellationToken)
+    {
+        const int MaxRetries = 5;
+        var defaultDelay = TimeSpan.FromMilliseconds(200);
+
+        for (var attempt = 1; ; attempt++, defaultDelay += defaultDelay)
+        {
+            TimeSpan? delayHint = null;
+            HttpResponseMessage? response = null;
+
+            try
+            {
+                using var request = requestFactory();
+                response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                if (!IsLastAttempt(attempt) && ShouldRetry(response, out delayHint))
+                {
+                    response.Dispose();
+                }
+                else
+                {
+                    return response;
+                }
+            }
+            catch (HttpRequestException) when (!IsLastAttempt(attempt))
+            {
+            }
+            catch (TaskCanceledException ex) when (ex.CancellationToken != cancellationToken && !IsLastAttempt(attempt))
+            {
+            }
+
+            await Task.Delay(delayHint is { } retryDelay && retryDelay > TimeSpan.Zero ? retryDelay : defaultDelay, cancellationToken).ConfigureAwait(false);
+        }
+
+        static bool IsLastAttempt(int attempt) => attempt >= MaxRetries;
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var socketHandler = new SocketsHttpHandler
+        {
+            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(1),
+            PooledConnectionLifetime = TimeSpan.FromMinutes(1),
+        };
+
+        return new HttpClient(socketHandler, disposeHandler: true);
+    }
+
+    private static bool ShouldRetry(HttpResponseMessage response, out TimeSpan? delay)
+    {
+        delay = GetRetryDelay(response);
+        return (int)response.StatusCode >= 500
+            || response.StatusCode is HttpStatusCode.RequestTimeout or (HttpStatusCode)429
+            || (response.StatusCode == HttpStatusCode.Forbidden && delay is not null);
+    }
+
+    private static TimeSpan? GetRetryDelay(HttpResponseMessage response)
+    {
+        if (response.Headers.RetryAfter is { } retryAfter)
+        {
+            return retryAfter switch
+            {
+                { Date: { } date } => date - DateTimeOffset.UtcNow,
+                { Delta: { } delta } => delta,
+                _ => null,
+            };
+        }
+
+        if (response.StatusCode == HttpStatusCode.Forbidden
+            && response.Headers.TryGetValues("X-RateLimit-Remaining", out var remainingValues)
+            && remainingValues.Any(static value => value == "0")
+            && response.Headers.TryGetValues("X-RateLimit-Reset", out var resetValues)
+            && long.TryParse(resetValues.FirstOrDefault(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var resetUnixTimeSeconds))
+        {
+            return DateTimeOffset.FromUnixTimeSeconds(resetUnixTimeSeconds) - DateTimeOffset.UtcNow;
+        }
+
+        return null;
+    }
+}

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -7,7 +7,6 @@ using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using Meziantou.Framework;
 using Meziantou.Framework.InlineSnapshotTesting;
-using Octokit;
 
 namespace Meziantou.RenovateConfig.Tests;
 
@@ -41,10 +40,7 @@ internal sealed class TestContext : IAsyncDisposable
             throw new InvalidOperationException("RENOVATE_TEST_TOKEN is required to run live Renovate system tests.");
         }
 
-        var github = new GitHubClient(new ProductHeaderValue("meziantou-renovate-config-tests"))
-        {
-            Credentials = new Octokit.Credentials(token),
-        };
+        var github = new GitHubClient(token);
 
         await CleanupLock.WaitAsync();
         try
@@ -121,20 +117,22 @@ internal sealed class TestContext : IAsyncDisposable
             ]);
     }
 
-    public async Task<IReadOnlyList<PullRequestInfo>> GetPullRequestsAsync(ItemStateFilter state = ItemStateFilter.All)
+    public async Task<IReadOnlyList<PullRequestInfo>> GetPullRequestsAsync(PullRequestState state = PullRequestState.All)
     {
-        var pullRequests = await _github.PullRequest.GetAllForRepository(
+        var pullRequests = await _github.GetPullRequestsAsync(
             TestRepository.Owner,
             TestRepository.Name,
-            new PullRequestRequest { Base = BaseBranch.Name, State = state });
+            BaseBranch.Name,
+            state,
+            Xunit.TestContext.Current.CancellationToken);
 
         var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
         var results = new List<PullRequestInfo>(pullRequests.Count);
 
         foreach (var pullRequest in pullRequests.OrderBy(static item => item.Title, StringComparer.Ordinal))
         {
-            var commits = await _github.PullRequest.Commits(TestRepository.Owner, TestRepository.Name, pullRequest.Number);
-            var merged = await _github.PullRequest.Merged(TestRepository.Owner, TestRepository.Name, pullRequest.Number);
+            var commits = await _github.GetPullRequestCommitsAsync(TestRepository.Owner, TestRepository.Name, pullRequest.Number, Xunit.TestContext.Current.CancellationToken);
+            var merged = await _github.IsPullRequestMergedAsync(TestRepository.Owner, TestRepository.Name, pullRequest.Number, Xunit.TestContext.Current.CancellationToken);
             var updates = new List<PackageUpdateInfo>();
             var markdown = Markdown.Parse(pullRequest.Body ?? string.Empty, pipeline);
             var table = markdown.OfType<Table>().FirstOrDefault();
@@ -214,7 +212,7 @@ internal sealed class TestContext : IAsyncDisposable
 
     public async Task AssertOpenPullRequestsHaveExpectedMetadataAsync()
     {
-        var pullRequests = await GetPullRequestsAsync(ItemStateFilter.Open);
+        var pullRequests = await GetPullRequestsAsync(PullRequestState.Open);
         Assert.NotEmpty(pullRequests);
         Assert.All(pullRequests, static pullRequest =>
         {
@@ -231,11 +229,10 @@ internal sealed class TestContext : IAsyncDisposable
         {
             await RunRenovateAsync();
 
-            var contents = await _github.Repository.Content.GetAllContentsByRef(TestRepository.Owner, TestRepository.Name, "project.csproj", BaseBranch.Name);
-            var content = contents.Single().Content;
+            var content = await _github.GetFileContentAsync(TestRepository.Owner, TestRepository.Name, "project.csproj", BaseBranch.Name, Xunit.TestContext.Current.CancellationToken);
             if (!content.Contains(obsoleteFileContent, StringComparison.Ordinal))
             {
-                var openPullRequests = await GetPullRequestsAsync(ItemStateFilter.Open);
+                var openPullRequests = await GetPullRequestsAsync(PullRequestState.Open);
                 Assert.Empty(openPullRequests);
                 var pullRequests = await GetPullRequestsAsync();
                 Assert.Contains(pullRequests, static pullRequest => pullRequest.Merged && pullRequest.Commits.Count > 0);
@@ -311,7 +308,7 @@ internal sealed class TestContext : IAsyncDisposable
 
     private static async Task CleanupExpiredBranches(ITestOutputHelper output, GitHubClient github)
     {
-        var branches = await github.Repository.Branch.GetAll(TestRepository.Owner, TestRepository.Name);
+        var branches = await github.GetBranchesAsync(TestRepository.Owner, TestRepository.Name, Xunit.TestContext.Current.CancellationToken);
         var expiredBases = branches
             .Select(static branch => TemporaryBaseBranchName.TryParse(branch.Name, out var parsed) ? parsed : null)
             .Where(static branch => branch is not null && branch.HasExpired(DateTimeOffset.UtcNow))
@@ -333,17 +330,19 @@ internal sealed class TestContext : IAsyncDisposable
 
     private static async Task CleanupTestRun(ITestOutputHelper output, GitHubClient github, TemporaryBaseBranchName baseBranch)
     {
-        var pullRequests = await github.PullRequest.GetAllForRepository(
+        var pullRequests = await github.GetPullRequestsAsync(
             TestRepository.Owner,
             TestRepository.Name,
-            new PullRequestRequest { Base = baseBranch.Name, State = ItemStateFilter.Open });
+            baseBranch.Name,
+            PullRequestState.Open,
+            Xunit.TestContext.Current.CancellationToken);
 
         foreach (var pullRequest in pullRequests)
         {
-            await github.PullRequest.Update(TestRepository.Owner, TestRepository.Name, pullRequest.Number, new PullRequestUpdate { State = ItemState.Closed });
+            await github.ClosePullRequestAsync(TestRepository.Owner, TestRepository.Name, pullRequest.Number, Xunit.TestContext.Current.CancellationToken);
         }
 
-        var branches = await github.Repository.Branch.GetAll(TestRepository.Owner, TestRepository.Name);
+        var branches = await github.GetBranchesAsync(TestRepository.Owner, TestRepository.Name, Xunit.TestContext.Current.CancellationToken);
         foreach (var branch in branches)
         {
             if (baseBranch.IsPartOfTestRun(branch.Name))
@@ -356,14 +355,7 @@ internal sealed class TestContext : IAsyncDisposable
     private static async Task DeleteBranch(ITestOutputHelper output, GitHubClient github, string branchName)
     {
         output.WriteLine($"Deleting test branch {branchName}");
-        try
-        {
-            await github.Git.Reference.Delete(TestRepository.Owner, TestRepository.Name, "heads/" + branchName);
-        }
-        catch (NotFoundException)
-        {
-            // A Renovate run can delete its branch before cleanup observes it.
-        }
+        await github.DeleteBranchAsync(TestRepository.Owner, TestRepository.Name, branchName, Xunit.TestContext.Current.CancellationToken);
     }
 
     private static string? ScrubVersions(string? value)

--- a/tests/renovate-config.tests.csproj
+++ b/tests/renovate-config.tests.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Markdig" Version="1.3.1" />
     <PackageReference Include="Meziantou.Framework.InlineSnapshotTesting" Version="5.0.12" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="2.0.8" />
-    <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Why
The live system tests depended on Octokit only for a small set of GitHub API operations. Replacing it with direct HttpClient calls removes that external dependency and keeps the GitHub integration logic explicit in this repository.

## What changed
- Added a new `GitHubClient` in `tests/GitHubClient.cs` that uses GitHub REST endpoints for pull requests, commits, merge status, branches, file content, closing PRs, and deleting branches.
- Added `tests/SharedHttpClient.cs` with retry behavior modeled after the shared retry pattern (transient failures, 429, timeouts, and rate-limit delay hints).
- Updated `tests/TestContext.cs` to use the new client instead of Octokit types and calls.
- Removed the `Octokit` package reference from `tests/renovate-config.tests.csproj`.

## Notes
The retry logic includes `Retry-After` handling and GitHub rate-limit reset handling (`X-RateLimit-Remaining`/`X-RateLimit-Reset`) to avoid flakiness in live test cleanup and polling flows.