### PR TITLE
Add docker regex for ImageSource.FromRegistry in C#

### DIFF
--- a/default.json
+++ b/default.json
@@ -26,7 +26,10 @@
     {
       "customType": "regex",
       "fileMatch": ["^.*\\.cs$"],
-      "matchStrings": ["\"(?<depName>ghcr\\.io/meziantou/[^:]+):(?<currentValue>.+?)\""],
+      "matchStrings": [
+        "\"(?<depName>ghcr\\.io/meziantou/[^:]+):(?<currentValue>.+?)\"",
+        "ImageSource\\.FromRegistry\\(\"(?<depName>.+):(?<currentValue>[^\"@]+)\"\\)"
+      ],
       "datasourceTemplate": "docker"
     },
     {

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -78,6 +78,7 @@ public sealed class SystemTests(ITestOutputHelper output)
             internal static class Container
             {
                 public const string Image = "ghcr.io/meziantou/meziantou-git-hub-actions-tracing:1.0.0";
+                public static readonly object RedisImage = ImageSource.FromRegistry("redis:8.2");
             }
             """);
         context.AddFile("install.sh",
@@ -91,6 +92,7 @@ public sealed class SystemTests(ITestOutputHelper output)
         await context.AssertPackagesDetectedAsync(
             "XUnitToFluentAssertionsAnalyzer",
             "ghcr.io/meziantou/meziantou-git-hub-actions-tracing",
+            "redis",
             "astral-sh/uv");
         await context.AssertOpenPullRequestsHaveExpectedMetadataAsync();
         context.MarkSuccessful();


### PR DESCRIPTION
This adds support for a common C# image declaration pattern so Renovate can detect and update Docker tags when images are defined with `ImageSource.FromRegistry("name:tag")`.

### What changed
1. Extended the C# regex manager in `default.json` with a new `matchStrings` entry that captures `depName` and `currentValue` from `ImageSource.FromRegistry("...")` calls.
2. Updated the live `CustomRegexManagersDetectDependencies` system test fixture to include `ImageSource.FromRegistry("redis:8.2")` and assert that `redis` is detected.

### Notes
N/A