### PR TITLE
Update Meziantou.NET.Sdk to 1.0.148

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,12 +3,15 @@
     "version": "10.0.301",
     "rollForward": "latestPatch"
   },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
   "msbuild-sdks": {
-    "Meziantou.NET.Sdk": "1.0.130",
-    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.130",
-    "Meziantou.NET.Sdk.Razor": "1.0.130",
-    "Meziantou.NET.Sdk.Test": "1.0.130",
-    "Meziantou.NET.Sdk.Web": "1.0.130",
-    "Meziantou.NET.Sdk.WindowsDesktop": "1.0.130"
+    "Meziantou.NET.Sdk": "1.0.148",
+    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.148",
+    "Meziantou.NET.Sdk.Razor": "1.0.148",
+    "Meziantou.NET.Sdk.Test": "1.0.148",
+    "Meziantou.NET.Sdk.Web": "1.0.148",
+    "Meziantou.NET.Sdk.WindowsDesktop": "1.0.148"
   }
 }

--- a/tests/renovate-config.tests.csproj
+++ b/tests/renovate-config.tests.csproj
@@ -12,10 +12,5 @@
     <PackageReference Include="Markdig" Version="1.3.1" />
     <PackageReference Include="Meziantou.Framework.InlineSnapshotTesting" Version="6.0.1" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="3.0.1" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update `Meziantou.NET.Sdk` to 1.0.148 in `global.json`.

- Opt in to Microsoft Testing Platform via the `test.runner` setting in `global.json`
- Remove the `xunit.v3` / `xunit.runner.visualstudio` package references, now added by `Meziantou.NET.Sdk.Test`
