### PR TITLE
Disable Renovate dependency dashboard issue

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,7 @@
     "group:allNonMajor"
   ],
   "ignorePresets": [":ignoreModulesAndTests"],
+  "dependencyDashboard": false,
   "configMigration": true,
   "reviewersFromCodeOwners": true,
   "regexManagers": [

--- a/tests/GitHubClient.cs
+++ b/tests/GitHubClient.cs
@@ -106,9 +106,20 @@ internal sealed class GitHubClient
             () => CreateRequest(HttpMethod.Delete, BuildUri($"repos/{Escape(owner)}/{Escape(repository)}/git/refs/heads/{EscapePath(branchName)}")),
             cancellationToken).ConfigureAwait(false);
 
+        // Deleting a branch must be idempotent: the same branch can be listed by multiple cleanup passes,
+        // and GitHub reports an already-deleted ref as 404 or as 422 "Reference does not exist".
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
             return;
+        }
+
+        if (response.StatusCode == HttpStatusCode.UnprocessableEntity)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (body.Contains("Reference does not exist", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
         }
 
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Adds `"dependencyDashboard": false` to the `default` preset so Renovate no longer creates the Dependency Dashboard issue (`config:recommended` enables it by default).

Repos already using this preset will have their existing dashboard issue closed by Renovate on the next run.

Validated with `npx renovate-config-validator default.json default-automerge.json renovate.json`.